### PR TITLE
fix(utils): add missing @staticmethod to convert_milliseconds_to_seconds (issue #13)

### DIFF
--- a/package/src/pyaslreport/utils/unit_conversion_utils.py
+++ b/package/src/pyaslreport/utils/unit_conversion_utils.py
@@ -30,6 +30,7 @@ class UnitConverterUtils:
             raise TypeError("Input must be an int, float, or list of int/float.")
 
 
+    @staticmethod
     def convert_milliseconds_to_seconds(values: int | float | list[int | float]) -> int | float | list[int | float]:
         """
         Convert milliseconds to seconds and round close values to integers.


### PR DESCRIPTION
Hello, @1brahimmohamed

Before this fix- 
```
BRANCH: master
@staticmethod present: False
UnitConverterUtils.convert_milliseconds_to_seconds(1800) = 1.8
PROBLEM: Without @staticmethod, 1800 is treated as 'self', function needs 'values' arg
Instance call CRASHES: UnitConverterUtils.convert_milliseconds_to_seconds() takes 1 positional argument but 2 were given
```
After the fix - 
```
BRANCH: fix/issue-13
@staticmethod present: True
UnitConverterUtils.convert_milliseconds_to_seconds(1800) = 1.8
```
The one line fix is now made. I am working on small bugs to familiarize myself with the codebase and I will keep reporting and fixing small bugs. When these PRs gets merged i will work on more complex issues either reported by someone else or if i find something. Thank you.
Resolves #13