### PR TITLE
fix(tests): correct endpoint URL and tighten assertion in test_get_report_dicom_with_invalid_file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@
 .history/
 *.ipynb
 .vscode/
+.venv*/
+__pycache__/
+uploads/
+node_modules/
+.env
+.env.local

--- a/apps/backend/tests/test_report.py
+++ b/apps/backend/tests/test_report.py
@@ -23,12 +23,12 @@ def test_get_report_dicom_with_invalid_file(tmp_path):
     file_path.write_text("not a dicom")
     with open(file_path, "rb") as f:
         response = client.post(
-            "/report/process/dicom",
+            "/api/report/process/dicom",
             files={"dcm_files": ("not_a_dicom.txt", f, "text/plain")},
             data={"modality": "ASL"}
         )
-    # Should still return 500 due to invalid dicom
-    assert response.status_code in [500, 200]
+    # Should return 500 — file reaches the endpoint but fails DICOM parsing
+    assert response.status_code == 500
 
 def test_report_pdf_endpoint():
     # Minimal valid report_data for rendering


### PR DESCRIPTION
Before this fix- 
```text
BRANCH: master
Wrong URL  '/report/process/dicom': status=404
```

After this fix - 
```
BRANCH: fix/issue-14
Correct URL '/api/report/process/dicom': status=500
test_report.py line 26: "/api/report/process/dicom",
```

The wrong URL was causing the test to always return a 404, which the vague assertion in [500, 200] failed to catch, masking the true behavior of the endpoint. The one line fix is now made. As mentioned, I am working on small bugs to familiarize myself with the codebase and I will keep reporting and fixing small bugs before moving to complex issues. Thank you. (ignore branch name)
Fixes #16 