### PR TITLE
fix(#24): remove dead code in get_bids_metadata and fix impossible test mocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@
 .history/
 *.ipynb
 .vscode/
+.venv*/
+__pycache__/
+uploads/
+node_modules/
+.env
+.env.local

--- a/package/src/pyaslreport/main.py
+++ b/package/src/pyaslreport/main.py
@@ -31,9 +31,6 @@ def get_bids_metadata(data):
     dicom_header = get_dicom_header(dicom_dir)
     sequence = get_sequence(modality, dicom_header)
     
-    if sequence is None:
-        raise ValueError(f"No matching sequence found for modality '{modality}' with the provided DICOM header")
-    
     return sequence.extract_bids_metadata()
 
 

--- a/package/src/pyaslreport/tests/test_package.py
+++ b/package/src/pyaslreport/tests/test_package.py
@@ -24,15 +24,16 @@ def test_get_bids_metadata_no_sequence():
     data = {"modality": "asl", "dicom_dir": "/fake/dir"}
     fake_header = MagicMock()
     with patch("pyaslreport.main.get_dicom_header", return_value=fake_header), \
-         patch("pyaslreport.main.get_sequence", return_value=None):
+         patch("pyaslreport.main.get_sequence", side_effect=ValueError("No ASL sequence class found that matches the DICOM header")):
         with pytest.raises(ValueError) as exc:
             get_bids_metadata(data)
-        assert "No matching sequence found" in str(exc.value)
+        assert "No ASL sequence class found" in str(exc.value)
 
 def test_get_bids_metadata_invalid_modality():
     data = {"modality": None, "dicom_dir": "/fake/dir"}
     fake_header = MagicMock()
     with patch("pyaslreport.main.get_dicom_header", return_value=fake_header), \
-         patch("pyaslreport.main.get_sequence", return_value=None):
-        with pytest.raises(ValueError):
+         patch("pyaslreport.main.get_sequence", side_effect=ValueError("Unsupported modality: None")):
+        with pytest.raises(ValueError) as exc:
             get_bids_metadata(data)
+        assert "Unsupported modality" in str(exc.value)


### PR DESCRIPTION
While looking through `get_bids_metadata()`, I noticed we were doing an `if sequence is None:` check on the result of the `get_sequence` factory. 

However, `get_sequence` actually never returns `None`—if it doesn't find a match, it raises a `ValueError` directly. So that check in [main.py](cci:7://file:///c:/Users/devgu/OneDrive/Desktop/osipi_gsoc_repos/osipi_gsoc_repo_3/ASL-Parameter-Generator/apps/backend/app/main.py:0:0-0:0) was just dead code. Because of this, two of our unit tests (`test_get_bids_metadata_no_sequence` and `test_get_bids_metadata_invalid_modality`) were mocking an impossible scenario by patching the factory to return `None`.

Here is the terminal verification before and after the fix:

**Before this fix:**
```text
BRANCH: master
main.py has 'if sequence is None': True
factory.py has 'return None': False
factory.py 'raise ValueError' count: 3
DEAD CODE: get_sequence() never returns None, always raises ValueError
test_package.py mocks return_value=None: True
```
**After the fix**

``` text
BRANCH: fix/issue-24
main.py has 'if sequence is None': False
factory.py has 'return None': False
factory.py 'raise ValueError' count: 3
test_package.py mocks return_value=None: False
```
In this PR:
1. Cleaned up the dead 3-line check in main.py
2. Updated the two unit tests to use side_effect=ValueError(...) instead, so they accurately test how the main method handles the real exception raised by the factory.

Resolves #24 